### PR TITLE
fix(index): update demo link to StackBlitz

### DIFF
--- a/src/html/index.html
+++ b/src/html/index.html
@@ -32,14 +32,14 @@
         <a href="#loaders">Loaders</a> /
         <a href="https://github.com/biesbjerg/ngx-translate-extract">Extractor</a> /
         <a href="#editors">Editors</a> /
-        <a href="https://plnkr.co/edit/WccVZSBM0rUgq2sXSUbe?p=preview" target="_blank">Demo</a>
+        <a href="https://stackblitz.com/github/ngx-translate/example" target="_blank">Demo</a>
     </div>
     <div class="content">
         <h3>What is ngx-translate?</h3>
         <p>
             NGX-Translate is an internationalization library for Angular. It lets you define translations for your
             content in different languages and switch between them easily.
-            Check out the <a href="https://embed.plnkr.co/pYo6bFPRRxVPgRR8toDt/" target="_blank">demo</a> on Plunker.
+            Check out the <a href="https://stackblitz.com/github/ngx-translate/example" target="_blank">demo</a> on StackBlitz.
         </p>
         <p>It gives you access to a service, a directive and a pipe to handle any dynamic or static content.</p>
         <p>NGX-Translate is also extremely modular. It is written in a way that makes it really easy to replace any part
@@ -104,4 +104,3 @@
 </script>
 </body>
 </html>
-


### PR DESCRIPTION
Hi!

I was looking to the documentation, but the demo link is not working anymore on Plunker and i saw you have a new one on StackBlitz.

I modified the link of the demo in the documentation to point to the StackBlitz one.

Thank you!
Have a nice day.